### PR TITLE
Goal 2 - Client can send holdRoom action to self, server; not yet to other clients.

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -85,7 +85,7 @@ class App extends Component {
   render() {
     return (
       <div className="App">
-        <Select store={store} />
+        <Select store={store} process={action => agent.process(action)} />
       </div>
     );
   }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -9,7 +9,6 @@ import { map } from "rxjs/operators";
 import { Agent, ajaxStreamingGet } from "antares-protocol";
 
 const agent = new Agent();
-agent.addFilter(({ action }) => store.dispatch(action));
 
 const url =
   process.NODE_ENV === "production"
@@ -29,6 +28,8 @@ const socketOccupancies = new Observable(notify => {
   });
 }).pipe(map(payload => ({ type: "setOccupancy", payload })));
 
+agent.addFilter(({ action }) => store.dispatch(action));
+agent.on("holdRoom", ({ action }) => socket.emit("holdRoom", action.payload));
 agent.subscribe(socketOccupancies);
 
 // TODO When any component processes a holdRoom action, forward it via the WS.

--- a/client/src/routes/Select.js
+++ b/client/src/routes/Select.js
@@ -1,7 +1,6 @@
 import React from "react";
 import RoomView from "../RoomView";
 import { connect } from "react-redux";
-import { process } from "../agent";
 
 export const chunkIntoFloors = roomViews => {
   const floors = [];
@@ -26,7 +25,7 @@ export const mapStateToProps = state => {
   return { floors };
 };
 
-export const Floor = ({ mini, children: rooms }) => (
+export const Floor = ({ mini, children: rooms, process }) => (
   <div className="floor">
     {rooms.map(room => (
       <RoomView
@@ -39,14 +38,16 @@ export const Floor = ({ mini, children: rooms }) => (
     ))}
   </div>
 );
-const Select = ({ floors }) => {
+const Select = ({ floors, process }) => {
   return (
     <div>
       <h2>Welcome to the Hotel California !</h2>
       <h3>Pick a room:</h3>
       <div className="hotel">
         {floors.map((floor, idx) => (
-          <Floor key={idx}>{floor}</Floor>
+          <Floor key={idx} process={process}>
+            {floor}
+          </Floor>
         ))}
       </div>
       <p style={{ position: "fixed", right: 0, top: 0, margin: 20 }}>

--- a/server.js
+++ b/server.js
@@ -97,6 +97,9 @@ io.on("connection", client => {
   });
 
   // TODO "holdRoom" types of client actions are ones we went to process
+  client.on("holdRoom", ({ num, hold }) => {
+    console.log("Recv: holdRoom, " + JSON.stringify({ num, hold }));
+  });
   // through our own agent/store so new clients get the current state
 
   // Be sure and clean up our resources when done


### PR DESCRIPTION
[Prev](https://github.com/deanius/hotel-california/pull/3) | [Next](https://github.com/deanius/hotel-california/pull/5)

In the last Goal, we made sure the server could talk to the clients in real-time. In this Goal, we'll complete wiring it up in the opposite direction. On the client we'll:

- [ ] Update UI components to process actions through the `agent` in their event handlers
- [ ] Emit messages to our websocket when we `process` a `holdRoom` action 

We can verify this by
- [ ] Seeing the UI occupancy change when we select rooms, and seeing Redux DevTools events
- [ ] Seeing the WebSocket Frames in Network DevTools

On the server we'll:
- [ ] Write to the console when we receive a `holdRoom` message

Which will be verified by 
- [ ] Seeing server log output when we receive a `holdRoom` message

![hotelcalifornia goal 2](https://user-images.githubusercontent.com/24406/49407487-675c9380-f71e-11e8-8dcf-33c909312353.gif)
