### PR TITLE
Goal 7 - Refactor front-end code for performance, less code.

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "dependencies": {
     "antares-protocol": ">=2.9.0",
+    "oboe": "^2.1.4",
     "react": "^16.5.2",
     "react-dom": "^16.5.2",
     "react-redux": "^5.1.0",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -51,11 +51,20 @@ if (document.location.hash === "#demo") {
 // TODO Return an Observable of the objects we recieve
 // in the callbacks of: socket.on("setOccupancy", ...)
 
+const callApi = async url => {
+  const response = await fetch(url);
+  const body = await response.json();
+
+  if (response.status !== 200) throw Error(body.message);
+
+  return body;
+};
+
 class App extends Component {
   componentDidMount() {
     // TODO With the objects field of the /api/rooms GET result
     // send it to the agent, not store, in an action of type `loadRooms`
-    this.callApi("/api/rooms")
+    callApi("/api/rooms")
       .then(({ objects }) => {
         store.dispatch({ type: "loadRooms", payload: objects });
       })
@@ -74,14 +83,6 @@ class App extends Component {
     agent.subscribe(restOccupancy);
   }
 
-  callApi = async url => {
-    const response = await fetch(url);
-    const body = await response.json();
-
-    if (response.status !== 200) throw Error(body.message);
-
-    return body;
-  };
 
   render() {
     return (

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6310,6 +6310,11 @@ http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
 
+http-https@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/http-https/-/http-https-1.0.0.tgz#2f908dd5f1db4068c058cd6e6d4ce392c913389b"
+  integrity sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=
+
 http-parser-js@>=0.4.0:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.13.tgz#3bd6d6fde6e3172c9334c3b33b6c193d80fe1137"
@@ -8685,6 +8690,13 @@ object.values@^1.0.4:
     es-abstract "^1.6.1"
     function-bind "^1.1.0"
     has "^1.0.1"
+
+oboe@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/oboe/-/oboe-2.1.4.tgz#20c88cdb0c15371bb04119257d4fdd34b0aa49f6"
+  integrity sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=
+  dependencies:
+    http-https "^1.0.0"
 
 obuf@^1.0.0, obuf@^1.1.1:
   version "1.1.2"


### PR DESCRIPTION
- [ ] We identify that system level things like API calling don't belong inside any particular component, and move them out.
- [ ] We use a library called Oboe that grants `ajaxStreamingGet` the power to stream. And we have to tweak it's `expandKey` property to preserve the same return objects as before. Thus we consolidate from 2 to 1 way to get data from the server.
- [ ] Having pulled out everything not related to UI state from our top-level App component, we make it a functional component again. 
- [ ] We clean 

We now have less code, and are forward compatible with React Hooks too! Our UI is easy to reason about: It is a functional transformation of the current state of the store, reconciled by React into the DOM. An Antares Agent is managing state transitions to the store via a filter, and its source of actions are two REST calls and a web socket connection.

We verify that 
- [ ] The app behaves as before, but with cleaner, easier to read code
- [ ] (Bonus!) We slow down the server response for `/api/rooms` and observe the client rendering rooms as they arrive instead of waiting until the end.